### PR TITLE
Change Global Constants to iota

### DIFF
--- a/const.go
+++ b/const.go
@@ -2,9 +2,9 @@ package imageupload
 
 // Global Constants
 const (
-	TIFF = 4
-	BMP  = 3
-	GIF  = 2
-	PNG  = 1
-	JPG  = 0
+	JPG = iota
+	PNG
+	GIF
+	BMP
+	TIFF
 )


### PR DESCRIPTION
Using iota in a sequence of numbers in vars/consts is good practice because if you have a lot of parameters, you will waste time checking the next one. It is the same as before, but cleaner.